### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/2867671761/3a83ce6c-dc56-45fb-8370-630035879fa7/0f365efa-4e36-4e63-9f3f-07add5cb7e2e/_apis/work/boardbadge/7b435834-40f1-41ae-8160-ce877dcc056c)](https://dev.azure.com/2867671761/3a83ce6c-dc56-45fb-8370-630035879fa7/_boards/board/t/0f365efa-4e36-4e63-9f3f-07add5cb7e2e/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/2867671761/3a83ce6c-dc56-45fb-8370-630035879fa7/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.